### PR TITLE
Fix CMakeLists.txt to point to GitHub; add docs

### DIFF
--- a/clients/cpp/CMakeLists.txt
+++ b/clients/cpp/CMakeLists.txt
@@ -37,10 +37,10 @@ find_package(glog CONFIG REQUIRED)
 
 message(STATUS "Downloading and extracting ICU4C...")
 file(
-        DOWNLOAD "http://download.icu-project.org/files/icu4c/61.1/icu4c-61_1-src.tgz" CMakeFiles/icu4c-61_1-src.tgz
-        EXPECTED_HASH SHA1=06ca7b1e64c28e07d5633a2e0257380884ea486b
+        DOWNLOAD "https://github.com/unicode-org/icu/releases/download/release-66-1/icu4c-66_1-src.tgz" CMakeFiles/icu4c-66_1-src.tgz
+        EXPECTED_HASH SHA1=68e87ea2044e92a5d86be6072b0eb3557f252d9f
 )
-execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/_3rdParty tar xfz ../CMakeFiles/icu4c-61_1-src.tgz)
+execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/_3rdParty tar xfz ../CMakeFiles/icu4c-66_1-src.tgz)
 
 add_executable(build_model_inc build_model_inc.cpp resources/zawgyiUnicodeModel.dat)
 target_link_libraries(build_model_inc -lpthread)

--- a/clients/cpp/README.md
+++ b/clients/cpp/README.md
@@ -2,6 +2,22 @@
 
 This documentation is for C++ specific usage of *Myanmar Tools*.  For general documentation, see [the top-level README](../../README.md).
 
+## Building
+
+From this directory:
+
+```bash
+$ cmake CMakeLists.txt
+$ make
+$ make test
+```
+
+The first line sets up your Makefiles and also downloads the dependencies: GLog, GTest, and ICU4C.  The second line builds the code (on Unix-style environments), and the third line runs the tests.
+
+Note: None of the dependencies need to be linked at runtime.  GLog and GTest are only used for testing and debugging.  ICU4C is used only for its header files; no library symbols are required.
+
+## Usage Examples
+
 To detect Zawgyi, create a singleton instance of ZawgyiDetector, and call `GetZawgyiProbability` with your `char*` UTF-8 string.
 
 ```cpp


### PR DESCRIPTION
FYI @sven-oly @srl295 @markusicu: old downloads from icu-project.org suddenly stopped working.  Probably related to the unicode.org server going down.  I got alerted about this from a build bot.  Updating the download paths to github.com should fix the problem.