### PR TITLE
Set token permissions for workflows

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,5 +1,7 @@
 name: CIFuzz
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/mynmr_tools_ci.yml
+++ b/.github/workflows/mynmr_tools_ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: '*'
 
+permissions:
+  contents: read
+
 jobs:
 
   # Training Data Project


### PR DESCRIPTION
Hi, as mentioned through email, this PR solves the [Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) check.

The security reason of specifying the permissions for the workflows is that GitHub, for default, grant write-all permission, which could be exploited in case of the workflow got compromised. 

Thus, it is both a recommendation from [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and the [Github](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) to always use credentials that are minimally scoped.

Workflow run with minimal permission:

- https://github.com/joycebrum/myanmar-tools/actions/runs/7010505449
- https://github.com/joycebrum/myanmar-tools/actions/runs/7010441060